### PR TITLE
Member

### DIFF
--- a/src/main/java/com/example/newsfeed_project/config/WebConfig.java
+++ b/src/main/java/com/example/newsfeed_project/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.example.newsfeed_project.config;
 
-import com.example.newsfeed_project.auth.LoginFilter;
+import com.example.newsfeed_project.filter.LoginFilter;
 import com.example.newsfeed_project.member.service.MemberService;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -10,16 +10,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class WebConfig {
 
-    private final MemberService memberService;
-
-    public WebConfig(MemberService memberService) {
-        this.memberService = memberService;
-    }
-
     @Bean
     public FilterRegistrationBean<Filter> filterRegistrationBean() {
         FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new LoginFilter(memberService));
+        registrationBean.setFilter(new LoginFilter());
         registrationBean.addUrlPatterns("/*");
         registrationBean.setOrder(2);
         return registrationBean;

--- a/src/main/java/com/example/newsfeed_project/filter/LoginFilter.java
+++ b/src/main/java/com/example/newsfeed_project/filter/LoginFilter.java
@@ -1,0 +1,74 @@
+package com.example.newsfeed_project.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.PatternMatchUtils;
+
+import java.io.IOException;
+
+@Slf4j
+public class LoginFilter implements Filter {
+
+    private static final String[] whiteList = {"/api/login", "/api/logout", "/members/register"};
+    private static final String SESSION_ID_KEY = "id";
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        String requestURI = request.getRequestURI();
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        try {
+            log.info("인증 체크 시작 - URI: {}, Method: {}, IP: {}",
+                    requestURI, request.getMethod(), request.getRemoteAddr());
+
+            // 화이트리스트 체크
+            if (isWhiteListPath(requestURI)) {
+                log.info("화이트리스트 경로 요청 - URI: {}", requestURI);
+                filterChain.doFilter(servletRequest, servletResponse);
+                return;
+            }
+
+            // /members/{id} 경로 처리
+            if (requestURI.matches("/members/\\d+")) {
+                log.info("/members/{id} 경로 요청 - URI: {}", requestURI);
+                filterChain.doFilter(servletRequest, servletResponse);
+                return;
+            }
+
+            if (isLoginCheckPath(requestURI)) {
+                log.info("인증 체크 로직 실행 - URI: {}", requestURI);
+
+                HttpSession session = request.getSession(false);
+
+                if (session == null || session.getAttribute(SESSION_ID_KEY) == null) {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다");
+                    log.info("미인증 사용자 요청 - URI: {}", requestURI);
+                    return;
+                }
+            }
+
+            // 필터 체인 계속 진행
+            filterChain.doFilter(request, response);
+
+        } catch (IOException | ServletException e) {
+            log.error("필터 처리 중 예외 발생 - URI: {}, Error: {}", requestURI, e.getMessage(), e);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "서버에서 오류가 발생했습니다.");
+        }
+    }
+
+    // 화이트리스트 경로인지 확인
+    private boolean isWhiteListPath(String requestURI) {
+        return PatternMatchUtils.simpleMatch(whiteList, requestURI);
+    }
+
+    // 인증 체크가 필요한 경로인지 확인
+    private boolean isLoginCheckPath(String requestURI) {
+        // 화이트리스트가 아니면 인증 체크 필요
+        return !isWhiteListPath(requestURI);
+    }
+}

--- a/src/main/java/com/example/newsfeed_project/friend/controller/FriendController.java
+++ b/src/main/java/com/example/newsfeed_project/friend/controller/FriendController.java
@@ -1,8 +1,8 @@
 package com.example.newsfeed_project.friend.controller;
 
+import com.example.newsfeed_project.friend.dto.AcceptFriendDto;
 import com.example.newsfeed_project.friend.dto.FriendDto;
 import com.example.newsfeed_project.friend.service.FriendService;
-import com.example.newsfeed_project.util.SessionUtil;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -21,41 +21,36 @@ public class FriendController {
 
 
     //친구 리스트 조회
-    @GetMapping("/friendList")
+    @GetMapping("/")
     public ResponseEntity<?> getFriendList(@RequestParam(defaultValue = "0") int page,
                                            @RequestParam(defaultValue = "10") int size,
                                            HttpSession session) {
-        String loggedInUserEmail = SessionUtil.validateSession(session);
-
-        Page<FriendDto> response = friendService.getApprovedFriendList(page, size, loggedInUserEmail);
+        Long loggedInUserId = (Long) session.getAttribute("id");
+        Page<FriendDto> response = friendService.getApprovedFriendList(page, size, loggedInUserId);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     // 친구 요청 생성
-    @PostMapping("/request")
+    @PostMapping("/")
     public ResponseEntity<String> sendFriendRequest(@RequestBody FriendDto friendDto, HttpSession session) {
-        String loggedInUserEmail = SessionUtil.validateSession(session);
-        friendService.sendFriendRequest(friendDto, loggedInUserEmail);
+
+        Long loggedInUserId = (Long) session.getAttribute("id");
+
+        friendService.sendFriendRequest(friendDto, loggedInUserId);
         return ResponseEntity.ok("친구 요청이 성공적으로 보내졌습니다.");
     }
 
     // 친구 요청 승인/거부 API
-    @PatchMapping("/accept/{requestId}")
+    @PatchMapping("/accept") //requestBody에 -> 따로 뽑아서 보내주게 설정
     public ResponseEntity<String> acceptFriendRequest(
-            @PathVariable Long requestId,
-            @RequestParam Long responseId,
-            @RequestParam boolean isAccepted,
+            @RequestBody AcceptFriendDto acceptFriendDto,
             HttpSession session) {
-
-        // 세션에서 현재 로그인된 사용자의 이메일 확인
-        String loggedInUserEmail = SessionUtil.validateSession(session);
-
+        Long loggedInUserId = (Long) session.getAttribute("id");
         // 서비스 레이어 호출: 요청 처리
-        friendService.acceptFriendRequest(requestId, responseId, isAccepted, loggedInUserEmail);
-
+        friendService.acceptFriendRequest(acceptFriendDto.getRequestId(), acceptFriendDto.isAccepted(), loggedInUserId);
         // 처리 결과 메시지 생성
-        String responseMessage = isAccepted ? "친구 요청이 수락되었습니다." : "친구 요청이 거절되었습니다.";
+        String responseMessage = acceptFriendDto.isAccepted() ? "친구 요청이 수락되었습니다." : "친구 요청이 거절되었습니다.";
         return ResponseEntity.ok(responseMessage);
     }
 
@@ -65,8 +60,8 @@ public class FriendController {
             @PathVariable Long requestId,
             @RequestParam Long responseId,
             HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("id");
 
-        String loggedInUserEmail = SessionUtil.validateSession(session);
         try {
             // 서비스 호출
             friendService.deleteFriendByResponseId(requestId, responseId);

--- a/src/main/java/com/example/newsfeed_project/friend/dto/AcceptFriendDto.java
+++ b/src/main/java/com/example/newsfeed_project/friend/dto/AcceptFriendDto.java
@@ -1,0 +1,15 @@
+package com.example.newsfeed_project.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+public class AcceptFriendDto {
+    private Long requestId;
+    private boolean isAccepted;
+}

--- a/src/main/java/com/example/newsfeed_project/friend/dto/FriendDto.java
+++ b/src/main/java/com/example/newsfeed_project/friend/dto/FriendDto.java
@@ -28,6 +28,5 @@ public class FriendDto {
         this.image = friend.getRequestFriend().getImage(); // 요청자의 이미지
         this.email = friend.getRequestFriend().getEmail(); // 요청자의 이메일
         this.name = friend.getRequestFriend().getName();   // 요청자의 이름
-        this.isApproval = friend.isFriendApproval();
     }
 }

--- a/src/main/java/com/example/newsfeed_project/friend/entity/Friend.java
+++ b/src/main/java/com/example/newsfeed_project/friend/entity/Friend.java
@@ -16,11 +16,11 @@ public class Friend {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private boolean friendApproval;
 
     private String status;
 
     private LocalDateTime updatedAt;
+    private String image;
 
     // 요청자
     @ManyToOne(cascade = CascadeType.PERSIST)
@@ -38,13 +38,11 @@ public class Friend {
 
     // 상태 업데이트
     public void approve() {
-        this.friendApproval = true;
         this.status = "APPROVED";
         this.updatedAt = LocalDateTime.now();
     }
 
     public void reject() {
-        this.friendApproval = false;
         this.status = "REJECTED";
     }
 

--- a/src/main/java/com/example/newsfeed_project/friend/repository/FriendRepository.java
+++ b/src/main/java/com/example/newsfeed_project/friend/repository/FriendRepository.java
@@ -11,13 +11,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
-    @Query("SELECT f FROM Friend f WHERE (f.requestFriend.email = :email OR f.responseFriend.email = :email) AND f.status = :status")
-    Page<Friend> findApprovedFriendsByEmail(@Param("email") String email, @Param("status") String status, Pageable pageable);
-
+    //무조건 pk 값
+    @Query("SELECT f FROM Friend f WHERE (f.requestFriend.id = :userId OR f.responseFriend.id = :userId) AND f.status = :status")
+    Page<Friend> findApprovedFriendsByUserId(@Param("userId") Long userId, @Param("status") String status, Pageable pageable);
     Optional<Friend> findByRequestFriendIdAndResponseFriendId(Long requestId, Long responseId);
-
-    @Query("SELECT f FROM Friend f WHERE f.id = :requestId AND f.status = :status")
-    Optional<Friend> findByIdAndStatus(@Param("requestId") Long requestId, @Param("status") String status);
 
     Optional<Friend> findByRequestFriendAndResponseFriend(Member requestFriend, Member responseFriend);
 }

--- a/src/main/java/com/example/newsfeed_project/friend/service/FriendService.java
+++ b/src/main/java/com/example/newsfeed_project/friend/service/FriendService.java
@@ -4,8 +4,8 @@ import com.example.newsfeed_project.friend.dto.FriendDto;
 import org.springframework.data.domain.Page;
 
 public interface FriendService {
-    void sendFriendRequest(FriendDto friendDto, String loggedInUserEmail);
-    void acceptFriendRequest(Long requestId, Long responseFriendId, boolean isApproved, String loggedInUserEmail);
+    void sendFriendRequest(FriendDto friendDto, Long loggedInUserId);
+    Page<FriendDto> getApprovedFriendList(int page, int size, Long loggedInUserId);
     void deleteFriendByResponseId(Long requestId, Long responseId);
-    Page<FriendDto> getApprovedFriendList(int page, int size, String email);
+    void acceptFriendRequest(Long requestId, boolean isApproved, Long loggedInUserId);
 }

--- a/src/main/java/com/example/newsfeed_project/member/controller/MemberController.java
+++ b/src/main/java/com/example/newsfeed_project/member/controller/MemberController.java
@@ -1,17 +1,13 @@
 package com.example.newsfeed_project.member.controller;
 
-import com.example.newsfeed_project.exception.NoAuthorizedException;
 import com.example.newsfeed_project.member.dto.*;
 import com.example.newsfeed_project.member.service.MemberService;
-import com.example.newsfeed_project.util.SessionUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.example.newsfeed_project.exception.ErrorCode.NO_AUTHOR_PROFILE;
 
 @RestController
 @RequestMapping("/members")
@@ -26,12 +22,13 @@ public class MemberController {
 
     @GetMapping("/{id}")
     public ResponseEntity<?> getProfile(@PathVariable Long id) {
-        MemberDto memberByEmail = memberService.getMemberById(id);
-        return ResponseEntity.status(HttpStatus.OK).body(memberByEmail);
+        MemberDto getMemberId = memberService.getMemberById(id);
+        return ResponseEntity.status(HttpStatus.OK).body(getMemberId);
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> createMember(@Valid @RequestBody MemberDto memberDto) {
+    public ResponseEntity<?> createMember(@Valid @RequestBody MemberDto memberDto, HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("id");
         MemberDto createdMember = memberService.createMember(memberDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdMember);
     }
@@ -39,50 +36,27 @@ public class MemberController {
     @PutMapping("/update")
     public ResponseEntity<MemberUpdateResponseDto> updateMember(
             @Valid @RequestBody MemberUpdateRequestDto requestDto,
-            HttpServletRequest request) {
-        // 세션에서 이메일 추출
-        String email = SessionUtil.validateSession(request.getSession(false));
+            HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("id");
 
         // 업데이트 서비스 호출
-        MemberUpdateResponseDto responseDto = memberService.updateMember(email, requestDto);
+        MemberUpdateResponseDto responseDto = memberService.updateMember(requestDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
-    @GetMapping("/email")
-    public ResponseEntity<?> findByEmail(@Valid @RequestParam String email, HttpServletRequest request) {
-        String sessionEmail = SessionUtil.validateSession(request.getSession(false));
-
-        if (!sessionEmail.equals(email)) {
-            throw new NoAuthorizedException(NO_AUTHOR_PROFILE);
-        }
-
-        MemberDto memberByEmail = memberService.getMemberByEmail(email);
-        return ResponseEntity.status(HttpStatus.OK).body(memberByEmail);
-    }
-
     @PutMapping("/password")
     public ResponseEntity<?> changePassword(@Valid @RequestBody PasswordRequestDto passwordRequestDto, HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("id");
         MemberDto memberDto = memberService.changePassword(passwordRequestDto.getOldPassword(), passwordRequestDto.getNewPassword(), session);
         return ResponseEntity.status(HttpStatus.OK).body(memberDto);
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<?> deleteMemberById(@Valid @RequestBody DeleteRequestDto deleteRequestDto, HttpServletRequest request) {
-        // 세션에서 이메일 확인
-        String email = SessionUtil.validateSession(request.getSession(false));
-        MemberDto existingMember = memberService.getMemberByEmail(email);
-
+    public ResponseEntity<?> deleteMemberById(@Valid @RequestBody DeleteRequestDto deleteRequestDto, HttpSession session) {
+        Long loggedInUserId = (Long) session.getAttribute("id");
         // 회원 탈퇴 처리 (비밀번호 검증 포함)
-        memberService.deleteMemberById(existingMember.getId(), deleteRequestDto.getPassword());
-
-
+        memberService.deleteMemberById(deleteRequestDto.getId(), deleteRequestDto.getPassword());
         return ResponseEntity.status(HttpStatus.OK).body("회원 삭제가 완료되었습니다.");
-    }
-
-    @PatchMapping("/{id}/restore")
-    public ResponseEntity<String> restoreMember(@PathVariable Long id) {
-        memberService.restoreMember(id);
-        return ResponseEntity.ok("회원이 복구되었습니다.");
     }
 }

--- a/src/main/java/com/example/newsfeed_project/member/dto/DeleteRequestDto.java
+++ b/src/main/java/com/example/newsfeed_project/member/dto/DeleteRequestDto.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DeleteRequestDto {
 
+    private Long id;
+
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }

--- a/src/main/java/com/example/newsfeed_project/member/dto/MemberDto.java
+++ b/src/main/java/com/example/newsfeed_project/member/dto/MemberDto.java
@@ -61,19 +61,21 @@ public class MemberDto {
                 .build();
     }
 
-    public MemberDto withPassword(String password) {
-        return MemberDto.builder()
-                .id(this.id)
-                .name(this.name)
-                .email(this.email)
-                .password(password)
-                .phoneNumber(this.phoneNumber)
-                .address(this.address)
-                .age(this.age)
-                .image(this.image)
-                .updatedAt(this.updatedAt)
-                .deletedAt(this.deletedAt)
-                .createdAt(this.createdAt)
+    //update
+    public void withPassword(String password) {
+        this.password = password;
+    }
+
+    public static Member toEntity(MemberDto memberDto) {
+        return Member.builder()
+                .name(memberDto.getName())
+                .email(memberDto.getEmail())
+                .password(memberDto.getPassword())
+                .phoneNumber(memberDto.getPhoneNumber())
+                .address(memberDto.getAddress())
+                .age(memberDto.getAge())
+                .image(memberDto.getImage())
+                .deletedAt(memberDto.getDeletedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/newsfeed_project/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/com/example/newsfeed_project/member/dto/MemberUpdateRequestDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberUpdateRequestDto {
+    private Long id;
     private String password;        // 현재 비밀번호
     private String name;            // 수정할 이름
     private String phoneNumber;     // 수정할 전화번호

--- a/src/main/java/com/example/newsfeed_project/member/entity/Member.java
+++ b/src/main/java/com/example/newsfeed_project/member/entity/Member.java
@@ -31,23 +31,11 @@ public class Member extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
-    @Version
     //낙관적 락
     //버전 관리를 통해 동시성 충돌 감지.
+    @Version
     private Integer version;
 
-    public static Member toEntity(MemberDto memberDtO) {
-        return Member.builder()
-                .name(memberDtO.getName())
-                .email(memberDtO.getEmail())
-                .password(memberDtO.getPassword())
-                .phoneNumber(memberDtO.getPhoneNumber())
-                .address(memberDtO.getAddress())
-                .age(memberDtO.getAge())
-                .image(memberDtO.getImage())
-                .deletedAt(memberDtO.getDeletedAt())
-                .build();
-    }
 
     public void updatedMember(MemberUpdateRequestDto updatedDto) {
         if (updatedDto.getName() != null) {
@@ -67,19 +55,8 @@ public class Member extends BaseEntity {
         }
     }
 
-    public Member withPassword(String password) {
-        return Member.builder()
-                .id(this.id)
-                .name(this.name)
-                .email(this.email)
-                .password(password) // 변경된 비밀번호
-                .phoneNumber(this.phoneNumber)
-                .address(this.address)
-                .age(this.age)
-                .image(this.image)
-                .deletedAt(this.deletedAt)
-                .version(this.version)
-                .build();
+    public void updatePassword(String password) {
+        this.password = password;
     }
 
     public void setDeletedAt(LocalDateTime deletedAt) {
@@ -92,10 +69,6 @@ public class Member extends BaseEntity {
 
     public boolean isDeleted() {
         return this.deletedAt != null;
-    }
-
-    public void restore() {
-        this.deletedAt = null;
     }
 }
 

--- a/src/main/java/com/example/newsfeed_project/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/newsfeed_project/member/repository/MemberRepository.java
@@ -9,24 +9,15 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    @Query("SELECT m FROM Member m WHERE m.email = :email AND m.deletedAt IS NULL")
-    Optional<Member> findByEmail(String email);
-
+    // PK와 삭제되지 않은 조건으로 멤버 조회
     @Query("SELECT m FROM Member m WHERE m.id = :id AND m.deletedAt IS NULL")
-    Optional<Member> findById(@Param("id") Long id);
+    Optional<Member> findByIdAndNotDeleted(@Param("id") Long id);
 
-    @Query("SELECT m FROM Member m WHERE m.deletedAt IS NULL")
-    List<Member> findAllActiveMembers();
+    // 이메일 중복 여부 확인
+    //@Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email AND m.deletedAt IS NULL")
+    boolean existsByEmail(@Param("email") String email);
 
-    // 삭제 여부와 관계없이 이메일로 회원 조회
-    @Query("SELECT m FROM Member m WHERE m.email = :email")
-    Optional<Member> findByEmailIncludingDeleted(@Param("email") String email);
-
-    // 삭제 여부와 관계없이 이메일 존재 여부 확인
-    @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email")
-    boolean existsByEmailIncludingDeleted(@Param("email") String email);
-
-    // 삭제되지 않은 상태에서 이메일 존재 여부 확인
-    @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.email = :email AND m.deletedAt IS NULL")
-    boolean existsByEmailAndDeletedAtIsNull(@Param("email") String email);
+    // 이메일로 멤버 조회
+    //@Query("SELECT m FROM Member m WHERE m.email = :email AND m.deletedAt IS NULL")
+    Optional<Member> findByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/example/newsfeed_project/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed_project/member/service/MemberService.java
@@ -8,13 +8,11 @@ import jakarta.servlet.http.HttpSession;
 
 public interface MemberService {
     MemberDto createMember(MemberDto memberDto);
-    MemberUpdateResponseDto updateMember(String email, MemberUpdateRequestDto requestDto);
+    MemberUpdateResponseDto updateMember(MemberUpdateRequestDto requestDto);
     MemberDto getMemberById(Long id);
-    MemberDto getMemberByEmail(String email);
     void deleteMemberById(Long id, String password);
     MemberDto changePassword(String oldPassword, String newPassword, HttpSession session);
     Member validateId(Long id);
-    Member validateEmail(String email);
-    boolean authenticate(String email, String password);
-    void restoreMember(Long id);
+    Member getByMemberByEmail(String email);
+    Long authenticateAndGetId(String email, String password);
 }


### PR DESCRIPTION
- 회원 기능 refactoring 
오늘 피드백 주신부분에서 회원 관련 부분 말씀드리겠습니다.
1. password 메서드 void로 수정해서 this.password로 변경
2.  Entity에 있던 toEntity 메서드 Dto로 이동
3.  LoginFilter email 값으로 받는것이 아닌 id pk 값으로 받을 수 있도록하고, 중복 되는 기능이 있기 때문에 지우기
4. MemberService에서 이메일 조회 할때 명명 좀더 명확히
5. MemberRepository에서 email 조회 부분 쿼리 사용 안해도 됨
6. loginFilter에서 util 기능을 하고 있기 때문에 필요하지 않음.


친구기능에서 친구 수락 하는 url 수정
친구 서비스 로직에서, page 처리할때  responseId와 requestId에 대한 id 값만 나오는 것 보다, name이라던지 image가 나오게 하면 좋을듯 하다고 하셨습니다.